### PR TITLE
Add missing object for token_generator call

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Promise {
 ### Token Generator
 
 ```javascript
-const response = token_generator(0)
+const response = artblocks.token_generator(0)
 ```
 
 ```javascript


### PR DESCRIPTION
I've been using and appreciating your module. 

Here I added the missing object for this sample `token_generator` function call in `README.md`